### PR TITLE
bump to v5.0.1 and update dependencies

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_3_API_29.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_6_Pro_API_33.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-10-05T08:24:08.004095Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-05-30T08:57:05.441405Z" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.0" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" default="true" project-jdk-name="zulu-16" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,15 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.test.piggybank"
-        minSdk 21
-        targetSdk 31
+        minSdk 24
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -32,20 +32,21 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
-    implementation 'app.rive:rive-android:2.0.4'
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-
-//    implementation 'com.getkeepsafe.relinker:relinker:1.4.4'
-//    implementation 'androidx.startup:startup-runtime:1.1.0'
-
-    testImplementation 'junit:junit:4.+'
-
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'app.rive:rive-android:5.0.1'
+    implementation "androidx.startup:startup-runtime:1.1.0"
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/java/com/test/piggybank/RivePiggyButton.kt
+++ b/app/src/main/java/com/test/piggybank/RivePiggyButton.kt
@@ -2,110 +2,108 @@ package com.test.piggybank
 
 
 import android.content.Context
-import android.graphics.SurfaceTexture
+import android.graphics.RectF
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleObserver
 import app.rive.runtime.kotlin.RiveTextureView
 import app.rive.runtime.kotlin.core.*
 import app.rive.runtime.kotlin.renderers.RendererSkia
 
 
 class RivePiggyButton(context: Context, attrs: AttributeSet?) : RiveTextureView(context, attrs) {
+    private lateinit var file: File
+    // Objects that the renderer needs for drawing
+    private lateinit var backgroundArtboard: Artboard;
+    private lateinit var piggyArtboard: Artboard;
 
+    // Object that the renderer needs to advance the state machines
+    private lateinit var piggyStateMachine: StateMachineInstance;
 
-    /** Our custom render loop!
-     *  calls to draw/advance will happen from a separate thread so beware!
-     */
-    override val renderer = object : RendererSkia() {
-        /**
-         * Draw our animation in its current state when android requests a draw operation.
-         *
-         * 1. Bind the canvas to our low level renderer
-         *  - the renderer will run draw operations against the canvas when requested.
-         * 2. Align the renderer, so it knows how to fit the artboard draw operations onto the canvas
-         * 3. Draw the background
-         * 4. Draw any flying coins
-         * 5. Draw the pig
-         */
-        override fun draw() {
+    // Object to set a state machine input (trigger)
+    private lateinit var pressedInput: SMITrigger;
 
-            save()
-            align(Fit.COVER, Alignment.CENTER,   AABB(width, height),backgroundArtboard.bounds,)
-
-            backgroundArtboard.drawSkia(cppPointer);
-
-            val copy = flyingCoins.toList()
-            for (pair in copy) {
-                pair.first.drawSkia(cppPointer);
-            }
-            piggyArtboard.drawSkia(cppPointer);
-            restore()
-        }
-
-        /**
-         * Advance the animation by some time.
-         *
-         * This is the crux of running rive animations, we apply the elapsed time to
-         * all active animations/ state machines.
-         *
-         * We know our flying coin animation lasts about 1.7 seconds.
-         * So we remove it once that amount of time has elapsed.
-         *
-         * And then we call "invalidateSelf" which tells android that this object needs to be drawn.
-         *
-         */
-        override fun advance(elapsed: Float) {
-            backgroundArtboard.advance(elapsed)
-            piggyStateMachineInstance.apply(piggyArtboard, elapsed)
-            piggyArtboard.advance(elapsed)
-            val removeMe: MutableList<Pair<Artboard, StateMachineInstance>> = mutableListOf()
-
-            for (pair in flyingCoins) {
-                flyingCoinTimes[pair] = flyingCoinTimes[pair] as Float + elapsed;
-                if (flyingCoinTimes[pair] as Float > 1.7) {
-                    removeMe.add(pair)
-                }
-                pair.second.apply(pair.first, elapsed);
-                pair.first.advance(elapsed);
-            }
-
-            for (pair in removeMe) {
-                flyingCoins.remove(pair);
-                flyingCoinTimes.remove(pair)
-            }
-        }
-    }
-
-
-    // Keep a reference to the file to keep resources around.
-    private val file: File = File(resources.openRawResource(R.raw.piggy).readBytes())
-
-    private val backgroundArtboard: Artboard = file.artboard("Background");
-    private val piggyArtboard: Artboard = file.artboard("Piggy");
-    private val coinArtboard: Artboard = file.artboard("Coin");
-
-
-    private val piggyStateMachineInstance: StateMachineInstance;
-    private val piggyStateMachine: StateMachine = piggyArtboard.stateMachine("PiggyMachine");
-    private val coinStateMachine: StateMachine = coinArtboard.stateMachine("CoinMachine");
-
-    private val pressedInput: SMITrigger;
-
+    // Reference to all coins, and their time alive
     private val flyingCoins: MutableList<Pair<Artboard, StateMachineInstance>> = mutableListOf()
     private val flyingCoinTimes: MutableMap<Pair<Artboard, StateMachineInstance>, Float> =
         mutableMapOf()
 
+    // Setup the Rive file and required objects
+    private fun setupFile(skRenderer: RendererSkia) {
+        val resource = resources.openRawResource(R.raw.piggy)
+        file = File(resource.readBytes())
+        resource.close()
 
-    init {
-        piggyStateMachineInstance = StateMachineInstance(piggyStateMachine)
-        pressedInput = piggyStateMachineInstance.input("Pressed") as SMITrigger
+        backgroundArtboard = file.artboard("Background");
+
+        piggyArtboard = file.artboard("Piggy");
+        piggyStateMachine = piggyArtboard.stateMachine("PiggyMachine")
+        pressedInput = piggyStateMachine.input("Pressed") as SMITrigger
+
+        // This will be deleted with its dependents.
+        skRenderer.dependencies.add(file)
     }
 
+    override fun createObserver(): LifecycleObserver {
+        return object : DefaultLifecycleObserver {
+            /* Optionally override lifecycle methods. */
+            // override fun onCreate(owner: LifecycleOwner) {
+            //     super.onCreate(owner)
+            // }
+            // override fun onDestroy(owner: LifecycleOwner) {
+            //     super.onDestroy(owner)
+            // }
+        }
+    }
+
+    override fun createRenderer(): RendererSkia {
+        val skRenderer = object : RendererSkia() {
+
+            override fun draw() {
+                save()
+                align(Fit.COVER, Alignment.CENTER,   RectF(0.0f, 0.0f, width, height),backgroundArtboard.bounds,)
+
+                backgroundArtboard.drawSkia(cppPointer);
+
+                val copy = flyingCoins.toList()
+                for (pair in copy) {
+                    pair.first.drawSkia(cppPointer);
+                }
+                piggyArtboard.drawSkia(cppPointer);
+                restore()
+
+            }
+
+            override fun advance(elapsed: Float) {
+                backgroundArtboard.advance(elapsed)
+                piggyStateMachine.advance(elapsed)
+                piggyArtboard.advance(elapsed)
+                val removeMe: MutableList<Pair<Artboard, StateMachineInstance>> = mutableListOf()
+
+                for (pair in flyingCoins) {
+                    flyingCoinTimes[pair] = flyingCoinTimes[pair] as Float + elapsed;
+                    if (flyingCoinTimes[pair] as Float > 1.7) {
+                        removeMe.add(pair)
+                    }
+                    pair.first.advance(elapsed)
+                    pair.second.advance(elapsed)
+                }
+
+                for (pair in removeMe) {
+                    flyingCoins.remove(pair);
+                    flyingCoinTimes.remove(pair)
+                }
+            }
+        }
+        // Call setup file only once we created the renderer.
+        setupFile(skRenderer)
+        return skRenderer
+    }
 
     /**
      * Someone presses anywhere on the screen, if its a down press lets make the piggy sing!
-      */
+     */
     override fun onTouchEvent(event: MotionEvent?): Boolean {
         // we want to trigger a coin animation when we detect a down press
         if (event?.action == MotionEvent.ACTION_DOWN) {
@@ -118,33 +116,31 @@ class RivePiggyButton(context: Context, attrs: AttributeSet?) : RiveTextureView(
     /**
      * Add a new coin into the mix.
      */
-    fun showMeTheMoney() {
+    private fun showMeTheMoney() {
         pressedInput.fire()
 
-        // create a new state machine instance for the coin state machine, so we can track
-        // its state separately to the other flying coins.
-        val coinStateMachineInstance = StateMachineInstance(coinStateMachine);
+        // create a new artboard and state machine instance, so we can track, draw, and update them
+        // separately to the other flying coins.
+        val coinArtboard = file.artboard("Coin");
+        val  coinStateMachine = coinArtboard.stateMachine("CoinMachine")
+
 
         // randomize the state machine input slightly so that the coins do not all follow the same path
-        val coinRandomInput = coinStateMachineInstance.input("CoinRandomization") as SMINumber;
+        val coinRandomInput = coinStateMachine.input("CoinRandomization") as SMINumber;
         coinRandomInput.value = (Math.random() * 100).toFloat();
-
-        // instantiate a fresh copy of the coinArtboard, this creates a new coin shape that we can
-        // move and animate, without impacting other flying coins
-        val coinArtboardInstance = coinArtboard.getInstance()
 
         // its time advance our coin, it forces the beginning key of the animation to be applied.
         // without this, the first frame would be how the artboard looks in design mode, in this case
         // a coin in the center of the artboard.
-        coinStateMachineInstance.apply(coinArtboardInstance, 0.0f);
-        coinArtboardInstance.advance(0.0f);
+        coinStateMachine.advance(0.0001f)
+        coinStateMachine.advance(0.0001f)
+        coinArtboard.advance(0.0001f)
 
         // track this pair so that we can advance the animation and discard it when the animation
         // is over.
-        val newPair = Pair(coinArtboardInstance, coinStateMachineInstance)
+        val newPair = Pair(coinArtboard, coinStateMachine)
         flyingCoins.add(newPair)
         flyingCoinTimes[newPair] = 0.0f
     }
-
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
 
     <com.test.piggybank.RivePiggyButton
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:7.0.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
+plugins {
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 04 15:01:06 BST 2021
+#Tue May 30 12:23:54 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,15 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "PiggyBank"


### PR DESCRIPTION
Some investigation is needed when initially advancing an artboard or state machine.

Keeping with the original example, when creating a new coin artboard I advance the artboard and state machine by 0, to ensure the coin does not start in the middle.

But I could not get it to work (the coin starting in the middle). What does work is if you call `coinStateMachine.advance(0f)` twice.

Currently the code is:
```kotlin
coinStateMachine.advance(0.001f)
coinStateMachine.advance(0.001f)
coinArtboard.advance(0.001f)
```

Because I first experimented with advancing with something bigger than 0, but the `0.001f` can be replaced with `0f`.